### PR TITLE
Fix modifier set and remove issue

### DIFF
--- a/Affenbox/Affenbox.ino
+++ b/Affenbox/Affenbox.ino
@@ -4143,6 +4143,7 @@ bool SetModifier(folderSettings *tmpFolderSettings)
     else
     {
       PlayMp3FolderTrack(260);
+      resetCurrentCard();
     }
     waitForTrackToFinish();
   }
@@ -4223,6 +4224,7 @@ bool RemoveModifier()
     mp3Pause();
     PlayMp3FolderTrack(261);
     waitForTrackToFinish();
+    resetCurrentCard();
   }
   return false;
 }


### PR DESCRIPTION
Abbreveations:
-Stop when card away mode → SWCA

Issues:
1. If currently there is no track playing after removing or setting the modifier, the track will skip to the next one
→ Because this is always the case in SWCA as you have to remove the music/audio book card to set or remove the modifier, this will alway happen in SWCA
2. In SWCA the modifier advertisement sound will be played twice, before the track is skipped to the next one

Explanation:
1. It seems to me that the "playAdvertisment(XX)" function is not working if no track is playing. That is probably the reason, why you are differing between the "isPlaying()" and the opposite case
2. Because of that you are yousing the "PlayMp3FolderTrack(XX)" function. If I got it right the DFMini Player doesn't support to go back to the exact same track position after using this
3. In SWCA when placing an audio book card on the Tonuino, the mp3.start() function will be called, which plays back the currently selected track - so the advertisment sound
4. Then the OnPlayFinished() function will be triggered which calls the nextTrack() function.
5. This causes the Tonuino to skip to the next track, even if the last one wasn't finished yet

Solution:
1. My solution to this is to call the resetCurrentCard() function to make the Tonuino forget the last audio book card
2. This will allow the Tonuino to playback the audio book at the last saved position - the start of the last played track
3.  Of course this is not the perfect solution, as this would be to go on with the track where it stopped before. But this seems not to be possible with the DFMini Player if I got it right